### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/scripts/package-plugin.js
+++ b/scripts/package-plugin.js
@@ -112,7 +112,7 @@ async function packagePlugin() {
               return false;
             }
           } else if (exclude.includes('*')) {
-            const pattern = new RegExp(exclude.replace('*', '.*'));
+            const pattern = new RegExp(exclude.replace(/\*/g, '.*'));
             if (pattern.test(relativePath)) {
               return false;
             }


### PR DESCRIPTION
Potential fix for [https://github.com/yo-han/moneybird-time-tracker/security/code-scanning/1](https://github.com/yo-han/moneybird-time-tracker/security/code-scanning/1)

To fix this, replace `exclude.replace('*', '.*')` with the correct, global replacement so that all asterisks in the pattern are replaced. The best method is to use a regular expression with the global flag: `exclude.replace(/\*/g, '.*')`. This ensures all `*` characters in a given exclude pattern are turned into `.*` for regex matching. No change in library imports is needed, as the fix is native JS. Simply update line 115 in the filter callback of `archive.directory`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
