### PR TITLE
refactor: extract moneybird utils and expand tests

### DIFF
--- a/src/services/moneybird.ts
+++ b/src/services/moneybird.ts
@@ -11,6 +11,7 @@ import {
   MoneybirdSalesInvoice,
 } from '../types/moneybird';
 import { format } from 'date-fns';
+import { formatMoneybirdDate, groupTimeEntriesByDescription } from '../utils/moneybird-utils';
 
 export class MoneybirdService {
   private baseUrl = 'https://moneybird.com/api/v2';
@@ -150,22 +151,6 @@ export class MoneybirdService {
     }
   }
 
-  private formatDate(date: Date): string {
-    const pad = (num: number) => num.toString().padStart(2, '0');
-
-    const year = date.getFullYear();
-    const month = pad(date.getMonth() + 1);
-    const day = pad(date.getDate());
-    const hours = pad(date.getHours());
-    const minutes = pad(date.getMinutes());
-    const offset = -date.getTimezoneOffset();
-    const offsetHours = Math.floor(Math.abs(offset) / 60);
-    const offsetMinutes = Math.abs(offset) % 60;
-    const offsetSign = offset >= 0 ? '+' : '-';
-
-    return `${year}-${month}-${day} ${hours}:${minutes}:00 ${offsetSign}${pad(offsetHours)}:${pad(offsetMinutes)}`;
-  }
-
   async startTimer(settings: TimerSettings): Promise<TimeEntry> {
     try {
       let billable = settings.billable;
@@ -177,7 +162,7 @@ export class MoneybirdService {
 
       const timeEntry = {
         time_entry: {
-          started_at: this.formatDate(new Date()),
+          started_at: formatMoneybirdDate(new Date()),
           user_id: settings.userId,
           project_id: settings.projectId,
           contact_id: settings.contactId || null,
@@ -214,7 +199,7 @@ export class MoneybirdService {
     try {
       const timeEntry = {
         time_entry: {
-          ended_at: this.formatDate(new Date()),
+          ended_at: formatMoneybirdDate(new Date()),
         },
       };
 
@@ -296,7 +281,7 @@ export class MoneybirdService {
       }
 
       // Group time entries by project and description
-      const groupedEntries = this.groupTimeEntries(timeEntries);
+      const groupedEntries = groupTimeEntriesByDescription(timeEntries);
 
       // Create invoice details from grouped entries
       const details_attributes = groupedEntries.map((group, index) => ({
@@ -334,43 +319,6 @@ export class MoneybirdService {
     } catch (error) {
       return this.handleAxiosError(error as AxiosError);
     }
-  }
-
-  private groupTimeEntries(timeEntries: MoneybirdTimeEntry[]): Array<{
-    description: string;
-    totalHours: number;
-    entries: MoneybirdTimeEntry[];
-  }> {
-    const groups: Record<
-      string,
-      {
-        description: string;
-        totalHours: number;
-        entries: MoneybirdTimeEntry[];
-      }
-    > = {};
-
-    timeEntries.forEach(entry => {
-      const key = entry.description || 'Werkzaamheden';
-
-      if (!groups[key]) {
-        groups[key] = {
-          description: key,
-          totalHours: 0,
-          entries: [],
-        };
-      }
-
-      const startTime = new Date(entry.started_at);
-      const endTime = new Date(entry.ended_at);
-      const durationMs = endTime.getTime() - startTime.getTime() - entry.paused_duration * 1000;
-      const hours = durationMs / (1000 * 60 * 60);
-
-      groups[key].totalHours += hours;
-      groups[key].entries.push(entry);
-    });
-
-    return Object.values(groups);
   }
 
   private async linkTimeEntriesToInvoice(

--- a/src/utils/moneybird-utils.ts
+++ b/src/utils/moneybird-utils.ts
@@ -25,17 +25,18 @@ export function formatMoneybirdDate(date: Date): string {
 export function groupTimeEntriesByDescription(
   timeEntries: MoneybirdTimeEntry[]
 ): GroupedTimeEntries[] {
-  const groups: Record<string, GroupedTimeEntries> = {};
+  const groups = new Map<string, GroupedTimeEntries>();
 
   for (const entry of timeEntries) {
     const key = entry.description || 'Werkzaamheden';
+    const existing = groups.get(key);
 
-    if (!groups[key]) {
-      groups[key] = {
+    if (!existing) {
+      groups.set(key, {
         description: key,
         totalHours: 0,
         entries: [],
-      };
+      });
     }
 
     const startTime = new Date(entry.started_at);
@@ -43,9 +44,13 @@ export function groupTimeEntriesByDescription(
     const durationMs = endTime.getTime() - startTime.getTime() - entry.paused_duration * 1000;
     const hours = durationMs / (1000 * 60 * 60);
 
-    groups[key].totalHours += hours;
-    groups[key].entries.push(entry);
+    const group = groups.get(key);
+    if (!group) {
+      continue;
+    }
+    group.totalHours += hours;
+    group.entries.push(entry);
   }
 
-  return Object.values(groups);
+  return Array.from(groups.values());
 }

--- a/src/utils/moneybird-utils.ts
+++ b/src/utils/moneybird-utils.ts
@@ -1,0 +1,51 @@
+import type { MoneybirdTimeEntry } from '../types/moneybird.js';
+
+type GroupedTimeEntries = {
+  description: string;
+  totalHours: number;
+  entries: MoneybirdTimeEntry[];
+};
+
+export function formatMoneybirdDate(date: Date): string {
+  const pad = (num: number) => num.toString().padStart(2, '0');
+
+  const year = date.getFullYear();
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  const hours = pad(date.getHours());
+  const minutes = pad(date.getMinutes());
+  const offset = -date.getTimezoneOffset();
+  const offsetHours = Math.floor(Math.abs(offset) / 60);
+  const offsetMinutes = Math.abs(offset) % 60;
+  const offsetSign = offset >= 0 ? '+' : '-';
+
+  return `${year}-${month}-${day} ${hours}:${minutes}:00 ${offsetSign}${pad(offsetHours)}:${pad(offsetMinutes)}`;
+}
+
+export function groupTimeEntriesByDescription(
+  timeEntries: MoneybirdTimeEntry[]
+): GroupedTimeEntries[] {
+  const groups: Record<string, GroupedTimeEntries> = {};
+
+  for (const entry of timeEntries) {
+    const key = entry.description || 'Werkzaamheden';
+
+    if (!groups[key]) {
+      groups[key] = {
+        description: key,
+        totalHours: 0,
+        entries: [],
+      };
+    }
+
+    const startTime = new Date(entry.started_at);
+    const endTime = new Date(entry.ended_at);
+    const durationMs = endTime.getTime() - startTime.getTime() - entry.paused_duration * 1000;
+    const hours = durationMs / (1000 * 60 * 60);
+
+    groups[key].totalHours += hours;
+    groups[key].entries.push(entry);
+  }
+
+  return Object.values(groups);
+}

--- a/tests/moneybird-utils.test.ts
+++ b/tests/moneybird-utils.test.ts
@@ -65,3 +65,39 @@ test('groupTimeEntriesByDescription groups entries and sums hours', () => {
   assert.equal(defaultGroup.entries.length, 1);
   assert.equal(defaultGroup.totalHours, 1);
 });
+
+test('groupTimeEntriesByDescription safely handles special object-key names', () => {
+  const entries: MoneybirdTimeEntry[] = [
+    {
+      id: '1',
+      started_at: '2026-02-01T10:00:00.000Z',
+      ended_at: '2026-02-01T11:00:00.000Z',
+      description: '__proto__',
+      billable: true,
+      user_id: 'u1',
+      contact_id: 'c1',
+      project_id: 'p1',
+      paused_duration: 0,
+      created_at: '2026-02-01T11:00:00.000Z',
+      updated_at: '2026-02-01T11:00:00.000Z',
+    },
+    {
+      id: '2',
+      started_at: '2026-02-01T11:00:00.000Z',
+      ended_at: '2026-02-01T12:00:00.000Z',
+      description: 'constructor',
+      billable: true,
+      user_id: 'u1',
+      contact_id: 'c1',
+      project_id: 'p1',
+      paused_duration: 0,
+      created_at: '2026-02-01T12:00:00.000Z',
+      updated_at: '2026-02-01T12:00:00.000Z',
+    },
+  ];
+
+  const grouped = groupTimeEntriesByDescription(entries);
+  assert.equal(grouped.length, 2);
+  assert.ok(grouped.find(group => group.description === '__proto__'));
+  assert.ok(grouped.find(group => group.description === 'constructor'));
+});

--- a/tests/moneybird-utils.test.ts
+++ b/tests/moneybird-utils.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { formatMoneybirdDate, groupTimeEntriesByDescription } from '../src/utils/moneybird-utils.js';
+import { MoneybirdTimeEntry } from '../src/types/moneybird.js';
+
+test('formatMoneybirdDate returns expected structure', () => {
+  const formatted = formatMoneybirdDate(new Date('2026-02-09T10:30:00.000Z'));
+
+  assert.match(formatted, /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:00 [+-]\d{2}:\d{2}$/);
+});
+
+test('groupTimeEntriesByDescription groups entries and sums hours', () => {
+  const entries: MoneybirdTimeEntry[] = [
+    {
+      id: '1',
+      started_at: '2026-02-01T10:00:00.000Z',
+      ended_at: '2026-02-01T11:00:00.000Z',
+      description: 'Build',
+      billable: true,
+      user_id: 'u1',
+      contact_id: 'c1',
+      project_id: 'p1',
+      paused_duration: 0,
+      created_at: '2026-02-01T11:00:00.000Z',
+      updated_at: '2026-02-01T11:00:00.000Z',
+    },
+    {
+      id: '2',
+      started_at: '2026-02-01T11:00:00.000Z',
+      ended_at: '2026-02-01T12:30:00.000Z',
+      description: 'Build',
+      billable: true,
+      user_id: 'u1',
+      contact_id: 'c1',
+      project_id: 'p1',
+      paused_duration: 1800,
+      created_at: '2026-02-01T12:30:00.000Z',
+      updated_at: '2026-02-01T12:30:00.000Z',
+    },
+    {
+      id: '3',
+      started_at: '2026-02-01T13:00:00.000Z',
+      ended_at: '2026-02-01T14:00:00.000Z',
+      description: '',
+      billable: true,
+      user_id: 'u1',
+      contact_id: 'c1',
+      project_id: 'p1',
+      paused_duration: 0,
+      created_at: '2026-02-01T14:00:00.000Z',
+      updated_at: '2026-02-01T14:00:00.000Z',
+    },
+  ];
+
+  const grouped = groupTimeEntriesByDescription(entries);
+  assert.equal(grouped.length, 2);
+
+  const buildGroup = grouped.find(group => group.description === 'Build');
+  assert.ok(buildGroup);
+  assert.equal(buildGroup.entries.length, 2);
+  assert.equal(buildGroup.totalHours, 2);
+
+  const defaultGroup = grouped.find(group => group.description === 'Werkzaamheden');
+  assert.ok(defaultGroup);
+  assert.equal(defaultGroup.entries.length, 1);
+  assert.equal(defaultGroup.totalHours, 1);
+});


### PR DESCRIPTION
## Why
Deze PR maakt `MoneybirdService` eenvoudiger en beter testbaar door pure domeinlogica uit de service te halen.

## What Changed
- `src/utils/moneybird-utils.ts` toegevoegd met:
  - `formatMoneybirdDate(date)`
  - `groupTimeEntriesByDescription(timeEntries)`
- `src/services/moneybird.ts` refactor:
  - gebruikt nu `formatMoneybirdDate` voor `started_at`/`ended_at`
  - gebruikt nu `groupTimeEntriesByDescription` voor invoice detail-opbouw
  - interne duplicatie van datum- en grouping-logica verwijderd
- `tests/moneybird-utils.test.ts` toegevoegd met unit tests voor:
  - datumformaat-output
  - grouping + urenberekening incl. `paused_duration`

## Behavioral Impact
- Geen bedoelde functionele wijziging in API-calls of payload-structuur.
- Refactor is intern: zelfde regels, verplaatst naar herbruikbare util-functies.

## Validation
Lokaal gedraaid:
- `npm run lint`
- `npm run test`
- `ROLLUP_WATCH=1 npm run build`

## Risks / Notes
- `formatMoneybirdDate` is op formaat getest; timezone/DST randgevallen kunnen nog uitgebreider.
- Groepering gebruikt bestaande floating-point berekening (ongewijzigd gedrag).

## Follow-up (optional)
- Extra tests voor DST-overgangen en exact payload-shape op service-niveau.
