### PR TITLE
chore(deps-dev): fix Dependabot alert #18 (tar)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "date-fns": "^4.1.0"
       },
       "devDependencies": {
-        "@elgato/cli": "^1.7.0",
+        "@elgato/cli": "^1.7.1",
         "@eslint/js": "^9.39.2",
         "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@elgato/cli": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@elgato/cli/-/cli-1.7.0.tgz",
-      "integrity": "sha512-Dui3m1KQCkqLg0Nc/cuZW9lgz5WWsqk1j3SVhanYd7W4P4i7zeokxIGFO7Odk00WE0L/URaOA6ZWKgSkeB0aHw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@elgato/cli/-/cli-1.7.1.tgz",
+      "integrity": "sha512-RJWjYi6hv/xhZpNr7TSnQ5h3n9dUr7CeCReiq1Bc6FOwsMH1hAn8MB9NQWhqGWTJZHPSubHp97K7x9+tsr2VBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4011,9 +4011,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "type": "module",
   "devDependencies": {
-    "@elgato/cli": "^1.7.0",
+    "@elgato/cli": "^1.7.1",
     "@eslint/js": "^9.39.2",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-json": "^6.1.0",


### PR DESCRIPTION
## Summary
- bump @elgato/cli from ^1.7.0 to ^1.7.1
- update lockfile so transitive tar resolves to 7.5.9 (patched)
- addresses Dependabot alert #18 (GHSA-83g3-92jg-28cx / CVE-2026-26960)

## Validation
- npm ci
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --json no longer contains GHSA-83g3-92jg-28cx
