### PR TITLE
fix(deps): override transitive fast-uri to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-aca7a812a8f46c11b",
+  "name": "moneybird-time-tracker",
   "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
@@ -2345,9 +2345,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -2358,7 +2358,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "serialize-javascript": "^7.0.5",
     "picomatch": "^4.0.4",
     "flatted": "^3.4.2",
-    "tar": "^7.5.13"
+    "tar": "^7.5.13",
+    "fast-uri": "3.1.2"
   },
   "engines": {
     "node": ">=24 <25"


### PR DESCRIPTION
## Summary

Patches the transitive `fast-uri` dependency to **3.1.2** to resolve two high-severity advisories. `fast-uri` is **not a direct dependency** — it is pulled in via `@elgato/cli` (devDependency) → `ajv` → `fast-uri`. Because the vulnerability is inside a transitive dependency, a direct `npm install` cannot upgrade it; instead an npm `overrides` block in `package.json` is used to force the resolved version across the dependency tree.

## Vulnerabilities

| Advisory | CVE | Severity | Summary |
|---|---|---|---|
| [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) | CVE-2026-6322 | high | Host confusion via percent-encoded authority delimiters in `fast-uri` |
| [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) | CVE-2026-6321 | high | Path traversal via percent-encoded dot segments in `fast-uri` |

## Change

Added to the existing `overrides` block in `package.json`:

```json
"overrides": {
  "fast-uri": "3.1.2"
}
```

## Verification

`npm ls fast-uri` confirms the override is applied across the dependency tree:

```
└─┬ @elgato/cli@1.7.1
  └─┬ ajv@8.18.0
    └── fast-uri@3.1.2 overridden
```

`package-lock.json` resolves `node_modules/fast-uri` to version `3.1.2`.

## Test status

- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm test` — passed (52/52)