### PR TITLE
chore: remove yarn packageManager field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-ab6e95f95aac670ad",
+  "name": "moneybird-time-tracker",
   "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,5 @@
   },
   "engines": {
     "node": ">=24 <25"
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }


### PR DESCRIPTION
## Why

Dependabot stopped regenerating `package-lock.json` on its PRs (#91, #94, #95 all failed CI with `npm ci` EUSAGE), forcing manual lockfile refreshes on every dependency bump.

Root cause: `package.json` declared `"packageManager": "yarn@1.22.22..."`. Dependabot uses this field to detect the package manager. Seeing "yarn", it looked for `yarn.lock` to update — but the repo only has `package-lock.json`. With no matching lockfile, Dependabot skipped the lockfile update entirely.

## Timeline

| Commit | Date | Effect |
|---|---|---|
| `1870c75` | 25 Oct 2025 | `packageManager` field removed → Dependabot worked correctly (e.g. #87 axios bump merged cleanly with lockfile updated) |
| `2c60b23` | 9 Feb 2026 | `packageManager: yarn@1.22.22` re-added as part of "harden repo and align node 24 tooling" |
| Feb–May 2026 | — | All subsequent Dependabot PRs land without lockfile updates → CI fails |

## Fix

Remove the `packageManager` field. The repo's actual tooling already uses npm:
- `package-lock.json` is present
- CI runs `npm ci`
- `actions/setup-node` uses `cache: 'npm'`

The `package-lock.json` `name` field also changes from a stray worktree directory name (`agent-afd5427415bf3f1b9`) back to `moneybird-time-tracker` — incidental side-effect of running `npm install` in the correct directory.

## Verification

- `rm -rf node_modules && npm ci` — clean
- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm test` — 52/52 pass

## Test plan

- [ ] Merge this PR
- [ ] Wait for the next Dependabot bump (or trigger one)
- [ ] Confirm Dependabot's PR now includes a regenerated `package-lock.json`
- [ ] Confirm CI's `npm ci` passes without manual intervention